### PR TITLE
WIP: Fix fetch-kde-qt.sh 

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,7 +14,7 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
-wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
+wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
 find -type f -name '*.mirrorlist' -delete
 
 csv=$(mktemp)


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/97391 you mentioned, that the fetch script was broken. Maybe this helps?!

Cause: signature file extension changed from "*.sha256" to "*.sig".

Fix: accept both for now
