### PR TITLE
Fix fetch-kde-qt.sh

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,16 +14,39 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
-wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' >/dev/null
+wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' -A '*.tar.xz.mirrorlist' -A '*.tar.xz.sha256' >/dev/null
+# for KDE:
+#  > wget will just find *.sig files - we'll fetch *.mirrorlist files manually and extract sha256 sums from the content
+# for QT:
+#  > wget will "traverse" *.mirrorlist files to find *.sha256 files
+# Keep *.sig files and *.sha256 files only
+
+# Delete *.mirrorlist (they were only needed to find *.sha256 files)
+find -type f -name '*.mirrorlist' -delete
+
+#read -p "See current files in $(pwd)"
 
 csv=$(mktemp)
-find . -type f | while read src; do
+# KDE sig files
+find . -type f -name '*.sig' | while read src; do
     filename="${src##*/}"
     filename="${filename%.sig}"
     mirrorlistFile="${filename}.mirrorlist"
     wget -c "${WGET_ARGS[@]}${mirrorlistFile}"
     # "parsing" html - this seems wrong, but could not find sha256 sums anywhere else for kde archives
     sha256=$(gawk -F "</*tr>|</*td>|<td style=\"[^\"]*\">" "/SHA256/ { print \$5 }" $mirrorlistFile)
+    nameVersion="${filename%.tar.*}"
+    name=$(echo "$nameVersion" | sed -e 's,-[[:digit:]].*,,' | sed -e 's,-opensource-src$,,' | sed -e 's,-everywhere-src$,,')
+    version=$(echo "$nameVersion" | sed -e 's,^\([[:alpha:]][[:alnum:]]*-\)\+,,')
+    path=$(dirname ${src:2})
+    echo "$name,$version,$sha256,$filename,$path" >>$csv
+done
+
+# QT sha256 files
+find . -type f -name '*.sha256' | while read src; do
+    filename="${src##*/}"
+    filename="${filename%.sha256}"
+    sha256=$(gawk '{ print $1 }' "$src")
     nameVersion="${filename%.tar.*}"
     name=$(echo "$nameVersion" | sed -e 's,-[[:digit:]].*,,' | sed -e 's,-opensource-src$,,' | sed -e 's,-everywhere-src$,,')
     version=$(echo "$nameVersion" | sed -e 's,^\([[:alpha:]][[:alnum:]]*-\)\+,,')

--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,7 +14,7 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
-wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
+wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
 find -type f -name '*.mirrorlist' -delete
 
 csv=$(mktemp)

--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,18 +14,24 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
-wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
-find -type f -name '*.mirrorlist' -delete
+wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' >/dev/null
 
 csv=$(mktemp)
 find . -type f | while read src; do
-    # Sanitize file name
-    filename=$(gawk '{ print $2 }' "$src" | tr '@' '_')
+    filename="${src##*/}"
+    filename="${filename%.sig}"
+    mirrorlistFile="${filename}.mirrorlist"
+    wget -c "${WGET_ARGS[@]}${mirrorlistFile}"
+    # "parsing" html - this seems wrong, but could not find sha256 sums anywhere else for kde archives
+    sha256=$(gawk -F "</*tr>|</*td>|<td style=\"[^\"]*\">" "/SHA256/ { print \$5 }" $mirrorlistFile)
     nameVersion="${filename%.tar.*}"
     name=$(echo "$nameVersion" | sed -e 's,-[[:digit:]].*,,' | sed -e 's,-opensource-src$,,' | sed -e 's,-everywhere-src$,,')
     version=$(echo "$nameVersion" | sed -e 's,^\([[:alpha:]][[:alnum:]]*-\)\+,,')
-    echo "$name,$version,$src,$filename" >>$csv
+    path=$(dirname ${src:2})
+    echo "$name,$version,$sha256,$filename,$path" >>$csv
 done
+
+#read -p "See CSV in $csv"
 
 cat >"$SRCS" <<EOF
 # DO NOT EDIT! This file is generated automatically.
@@ -38,10 +44,10 @@ EOF
 gawk -F , "{ print \$1 }" $csv | sort | uniq | while read name; do
     versions=$(gawk -F , "/^$name,/ { print \$2 }" $csv)
     latestVersion=$(echo "$versions" | sort -rV | head -n 1)
-    src=$(gawk -F , "/^$name,$latestVersion,/ { print \$3 }" $csv)
+    sha256=$(gawk -F , "/^$name,$latestVersion,/ { print \$3 }" $csv)
     filename=$(gawk -F , "/^$name,$latestVersion,/ { print \$4 }" $csv)
-    url="$(dirname "${src:2}")/$filename"
-    sha256=$(gawk '{ print $1 }' "$src")
+    path=$(gawk -F , "/^$name,$latestVersion,/ { print \$5 }" $csv)
+    url="$path/$filename"
     cat >>"$SRCS" <<EOF
   $name = {
     version = "$latestVersion";


### PR DESCRIPTION
###### Motivation for this change

Rewriting part of the fetch-kde-qt.sh script.

The sha256 checksums moved to the content of html (sic!) mirrorlist subpages that aren't automatically fetched by a recursive wget download anymore.

* Just fetch *.sig files
* Construct mirrorlist subpage link from that
* Fetch mirrorlist subpages
* Extract sha256 from html content

I'd like to have a more fresh KDE - so maybe this helps progressing in https://github.com/NixOS/nixpkgs/pull/97391

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

